### PR TITLE
Update links in readme.  Clarify that the RTSP firmware does is not a full SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 # Wyzecam API (unofficial, reverse engineered for experimental use only).
 
-# Note: May 15 2019: Project has been discontinued. Please use RTSP protocol. Infos @ https://forums.wyzecam.com/t/real-time-streaming-protocol-rtsp/6694/552
+# Note: May 15 2019: Project has been discontinued.
+- ***Wyze now provides a RTSP firmware allow you to stream video from cameras. Info @ [https://support.wyzecam.com/hc/en-us/articles/360026245231-Wyze-Cam-RTSP]()***
+- ***Wyze does not provide a general API/SDK for developers. The request for this and Wyze's response [is available here](https://forums.wyzecam.com/t/api-for-developers/32845)***
+
+===
+---
+===
+
 
 Wyzecams are awesome. At 19$, these are the perfect Wi-Fi cameras. They are reliable, well built and the Wyzecam mobile app is well made. But, the mobile application lacks a feature I really need: a way to access the cameras feed outside its walled garden. This repository is my attempt to document the Wyzecam API protocol to locally get my cameras feed in a cross-platform desktop application.
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Wyzecam API (unofficial, reverse engineered for experimental use only).
 
 # Note: May 15 2019: Project has been discontinued.
-- ***Wyze now provides a RTSP firmware allow you to stream video from cameras. Info @ [https://support.wyzecam.com/hc/en-us/articles/360026245231-Wyze-Cam-RTSP]()***
-- ***Wyze does not provide a general API/SDK for developers. The request for this and Wyze's response [is available here](https://forums.wyzecam.com/t/api-for-developers/32845)***
+- ### Wyze now provides RTSP firmware which can be installed to allow you to stream video from WyzeCams. Info @ https://support.wyzecam.com/hc/en-us/articles/360026245231-Wyze-Cam-RTSP
+- ### Wyze does not yet provide a general API/SDK for developers. Users have requested this and Wyze's current response [is available here](https://forums.wyzecam.com/t/api-for-developers/32845)
 
-===
+
 ---
-===
+<br/>
 
 
 Wyzecams are awesome. At 19$, these are the perfect Wi-Fi cameras. They are reliable, well built and the Wyzecam mobile app is well made. But, the mobile application lacks a feature I really need: a way to access the cameras feed outside its walled garden. This repository is my attempt to document the Wyzecam API protocol to locally get my cameras feed in a cross-platform desktop application.


### PR DESCRIPTION
This repo is the #2 Google search result for "Wyze API".  The existing RTSP link is a bit confusing, so updating it to the help article from Wyze that documents this more clearly.  Also added a link to the API/SDK Wishlist request created by Wyze users.
